### PR TITLE
Add null check for attendee.getCustomPronoun() in AttendeeBadgeDTO

### DIFF
--- a/src/main/java/org/kumoricon/registration/print/formatter/badgeimage/AttendeeBadgeDTO.java
+++ b/src/main/java/org/kumoricon/registration/print/formatter/badgeimage/AttendeeBadgeDTO.java
@@ -109,7 +109,7 @@ public class AttendeeBadgeDTO {
         output.setFanName(attendee.getFanName());
         output.setBadgeNumber(attendee.getBadgeNumber());
 
-        String attendeePronoun = attendee.getCustomPronoun().isEmpty() ? attendee.getPreferredPronoun() : attendee.getCustomPronoun();
+        String attendeePronoun = determineAttendeePronoun(attendee);
         output.setPronoun(attendeePronoun);
 
         output.setBadgeTypeText(badge.getBadgeTypeText());
@@ -133,5 +133,13 @@ public class AttendeeBadgeDTO {
         output.setAgeStripeBackgroundColor("#FF0099");
         output.setAgeStripeText("Guest");
         return output;
+    }
+
+    private static String determineAttendeePronoun(Attendee attendee) {
+        if (attendee.getCustomPronoun() == null || attendee.getPreferredPronoun().isEmpty()) {
+            return attendee.getPreferredPronoun();
+        }
+
+        return attendee.getCustomPronoun();
     }
 }


### PR DESCRIPTION
pre-reg orders may not have customPronoun assigned. add null check to avoid NPE when checking if string is empty

![attendee_import_err](https://user-images.githubusercontent.com/53846457/181834908-e7759d3b-38e3-4548-a195-6f1dc1963479.png)

