### PR TITLE
fix badgeMap membershipType mismatch in attendee import

### DIFF
--- a/src/main/java/org/kumoricon/registration/guest/AttendeeImporterService.java
+++ b/src/main/java/org/kumoricon/registration/guest/AttendeeImporterService.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 @Service
 public class AttendeeImporterService {
     public static final String IMPORT_TILL_NAME = "Attendee Import";
+    private static final String REPLACE_REGEX = "[^A-Za-z0-9]";
     private final TillSessionService sessionService;
 
     private final OrderRepository orderRepository;
@@ -66,7 +67,7 @@ public class AttendeeImporterService {
     private HashMap<String, Badge> getBadgeMap() {
         HashMap<String, Badge> badges = new HashMap<>();
         for (Badge b : badgeService.findAll()) {
-            badges.put(b.getName().replaceAll("[^A-Za-z0-9]", "").toLowerCase(), b);
+            badges.put(b.getName().replaceAll(REPLACE_REGEX, "").toLowerCase(), b);
         }
         // Add special cases - you can't buy day badges online, but they can be created
         badges.put("regularday1", badges.get("friday"));
@@ -389,9 +390,9 @@ public class AttendeeImporterService {
 
         String lowerCaseMembershipType;
         if (person.vipLevel().isEmpty()) {
-            lowerCaseMembershipType = person.membershipType().toLowerCase();
+            lowerCaseMembershipType = person.membershipType().replaceAll(REPLACE_REGEX, "").toLowerCase();
         } else {
-            lowerCaseMembershipType = "vip" + person.vipLevel().toLowerCase();
+            lowerCaseMembershipType = "vip" + person.vipLevel().replaceAll(REPLACE_REGEX, "").toLowerCase();
         }
         if (badgeMap.containsKey(lowerCaseMembershipType)) {
             attendee.setBadgeId(badgeMap.get(lowerCaseMembershipType).getId());


### PR DESCRIPTION
getting failures during attendee import due to mismatch when checking membershipType against badgeMap keys (whitespace removed in badgeMap keys but not when getting membershipType)
```
java.lang.RuntimeException: Unknown badge type Emerging Press
	at org.kumoricon.registration.guest.AttendeeImporterService.updateAttendeeFromPerson(AttendeeImporterService.java:403) ~[classes/:na]
	at org.kumoricon.registration.guest.AttendeeImporterService.importFromObjects(AttendeeImporterService.java:258) ~[classes/:na]
	at org.kumoricon.registration.guest.AttendeeImporterService$$FastClassBySpringCGLIB$$862025b7.invoke(<generated>) ~[classes/:na]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.23.jar:5.3.23]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.23.jar:5.3.23]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.23.jar:5.3.23]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.23.jar:5.3.23]
	at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123) ~[spring-tx-5.3.23.jar:5.3.23]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:388) ~[spring-tx-5.3.23.jar:5.3.23]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119) ~[spring-tx-5.3.23.jar:5.3.23]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.23.jar:5.3.23]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.23.jar:5.3.23]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:708) ~[spring-aop-5.3.23.jar:5.3.23]
	at org.kumoricon.registration.guest.AttendeeImporterService$$EnhancerBySpringCGLIB$$2f0012e9.importFromObjects(<generated>) ~[classes/:na]
	at org.kumoricon.registration.guest.AttendeeImportService.importFile(AttendeeImportService.java:74) ~[classes/:na]
	at org.kumoricon.registration.model.ImportService.doWork(ImportService.java:28) ~[classes/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[na:na]
	at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[spring-context-5.3.23.jar:5.3.23]
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-5.3.23.jar:5.3.23]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) ~[na:na]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
```

debug logging
```
2023-10-20 07:18:53.468 - INFO 16820 --- [pool-1-thread-1] o.k.r.guest.AttendeeImporterService      :  BADGEMAP KEYS: [weekendmilitarydiscount, saturday, smallpress, exhibitor, vipcumulus, artist, weekend, industry, emergingpress, regularday3, regularday2, regularday1, standardpress, sunday, panelist, vipaltocumulus, friday, guest, vipcumulonimbus]
2023-10-20 07:18:53.468 - INFO 16820 --- [pool-1-thread-1] o.k.r.guest.AttendeeImporterService      :  MEMBERSHIP TYPE: emerging press
```