### PR TITLE
update vip badges to only have vip-primary for 2023

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Version 2.0.4 (Pending)
 - Add interceptor to update user rights without forcing relog
 - Update staff search to search for multiple first/last names
 - Add a save & reprint option on edit attendee order page
+- Fix mismatch between badge type & membership type in attendee import
+- Update VIP levels for 2023 to only have Primary VIP level
 
 Version 2.0.3 (11/08/2022)
 - Use regular font for attendee badge names - Myriad Pro Bold is missing symbols

--- a/src/main/java/org/kumoricon/registration/BaseDataService.java
+++ b/src/main/java/org/kumoricon/registration/BaseDataService.java
@@ -314,9 +314,7 @@ public class BaseDataService {
 
         // Create badge types with security restrictions below
         List<Badge> vipBadges = new ArrayList<>();
-        vipBadges.add(BadgeFactory.createBadge("VIP-Cumulus", BadgeType.VIP, "Weekend", "#000000", 250, 250, 250));
-        vipBadges.add(BadgeFactory.createBadge("VIP-Altocumulus", BadgeType.VIP, "Weekend", "#000000", 450, 450, 450));
-        vipBadges.add(BadgeFactory.createBadge("VIP-Cumulonimbus", BadgeType.VIP, "Weekend", "#000000", 600, 600, 600));
+        vipBadges.add(BadgeFactory.createBadge("VIP-Primary", BadgeType.VIP, "Weekend", "#000000", 500, 500, 500));
 
         for (Badge vip : vipBadges) {
             log.info("Creating badge {}", vip.getName());

--- a/src/main/java/org/kumoricon/registration/reports/attendance/AttendanceReportController.java
+++ b/src/main/java/org/kumoricon/registration/reports/attendance/AttendanceReportController.java
@@ -19,7 +19,7 @@ import java.util.*;
 public class AttendanceReportController {
     private final AttendeeSearchRepository attendeeSearchRepository;
     private final StaffRepository staffRepository;
-    private final String[] ATTENDEE_BADGE_TYPES = {"wednesday", "thursday", "friday", "saturday", "sunday", "weekend", "vip", "vip-cumulus", "vip-altocumulus", "vip-cumulonimbus"};
+    private final String[] ATTENDEE_BADGE_TYPES = {"wednesday", "thursday", "friday", "saturday", "sunday", "weekend", "vip", "vip-primary"};
     private final String[] VENDOR_BADGE_TYPES = {"artist", "exhibitor"};
 
     public AttendanceReportController(AttendeeSearchRepository attendeeSearchRepository,


### PR DESCRIPTION
there's only one VIP level for 2023 `vipLevel: Primary`. this pr updates to only have the primary vip level