### PR TITLE
Make price override required for at con specialty attendees

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change History
-Version 2.1.3 (Pending)
+Version 2.1.4 (Pending)
+- Make price override required for at con specialty attendees
+
+Version 2.1.3 (11/17/2023)
 - Move failing inline reg imports to DLQ
 
 Version 2.1.2 (11/17/2023)

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.kumoricon</groupId>
 	<artifactId>registration</artifactId>
-	<version>2.1.3</version>
+	<version>2.1.4</version>
 	<name>registration</name>
 	<description>Attendee registration system</description>
 

--- a/src/main/resources/static/js/attendeeform.js
+++ b/src/main/resources/static/js/attendeeform.js
@@ -177,6 +177,10 @@ function readyToSaveSpeciality() {
     // Vastly reduced field enforcement -- we assume that Speciality coords have a reason for doing anything
     // For example, they can create badges that don't have first or last name at all, or a birthdate
     // It is required that you have either a firstname and lastname OR a fan name, though.
-    return ($("#inputFirstName").val() !== "" && $("#inputLastName").val() !== "") ||
-        $("#inputFanName").val() !== "";
+
+    // For 2023 specifically, the specialty badge prices can be variable depending on if they purchased WiFi or not
+    // For a temp fix, require the user to put in a price override for specialty attendees
+    return $("#inputPaidAmount").val() !== "" &&
+        (($("#inputFirstName").val() !== "" && $("#inputLastName").val() !== "") ||
+        ($("#inputFanName").val() !== "" && $("#inputPaidAmount").val() !== ""));
 }


### PR DESCRIPTION
For 2023 specifically, the specialty badge prices can be variable depending on if they purchased WiFi or not
For a temp fix, require the user to put in a price override for specialty attendees
